### PR TITLE
Specify license version

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,7 +26,7 @@
 				<!-- Copyright -->
 					<div class="copyright">
 						<ul class="menu">
-							<li>&copy; MISP project. Software released under the AGPL license and content released as CC-BY-SA.</li><li><img src="{{ site.baseurl }}/assets/images/en_cef.png" width="50%" height="50%"/></li>
+							<li>&copy; MISP project. Software released under the AGPL license and content released as CC BY-SA 3.0.</li><li><img src="{{ site.baseurl }}/assets/images/en_cef.png" width="50%" height="50%"/></li>
 						</ul>
 					</div>
 


### PR DESCRIPTION
To make it possible to copy content to Wikipedia from the website, the CC BY-SA license version has to be specified. The 4.0 version is basically the same, but incompatible with Wikipedia, so 3.0 is the preferred version.[1] 

[1] https://en.wikipedia.org/wiki/Wikipedia:FAQ/Copyright#cite_note-2