### PR TITLE
fix: [blog] MISP BEST PRACTICES FOR ENCODING THREAT INTELLIGENCE broken link

### DIFF
--- a/content/blog/Video_MISP_Best_practices_for_encoding_threat_intelligence.md
+++ b/content/blog/Video_MISP_Best_practices_for_encoding_threat_intelligence.md
@@ -12,7 +12,7 @@ banner: /img/blog/graph-syria.png
 ## Content of Training Session
 
 - [MISP data model introduction](https://github.com/MISP/misp-training/blob/main/complementary/other-slides/a.11.a-misp-data-model-overview.pdf)
-- [Best practices - from evidences to actionable evidences](https://github.com/MISP/misp-training/blob/main/complementary/other-slides/MISP%208%20Commandments%20-%20Recommendations%20and%20Best%20Practices%20when%20encoding%20data.pdf)
+- [Best practices - from evidences to actionable evidences](https://github.com/MISP/misp-training/blob/main/complementary/other-slides/MISP%2010%20Commandments%20-%20Recommendations%20and%20Best%20Practices%20when%20encoding%20data.pdf)
 - Leveraging the information in MISP to Make Threat Landscape Report
 
 [Jupyter notebook](https://github.com/MISP/misp-training/blob/ffd36c92e909571dc525ed45a142d604dc912278/a.7-rest-API/query-misp.ipynb) used during the training session.


### PR DESCRIPTION
Thanks for the nice documentation :)

I found a broken link in the article below, So I fixed it.
- https://www.misp-project.org/2022/12/15/Video_MISP_Best_practices_for_encoding_threat_intelligence.html/

The broken link is as follows.
- [Best practices - from evidences to actionable evidences](https://github.com/MISP/misp-training/blob/main/complementary/other-slides/MISP%208%20Commandments%20-%20Recommendations%20and%20Best%20Practices%20when%20encoding%20data.pdf)

Regards.