### PR TITLE
chg: [blog] update recommended Ubuntu version

### DIFF
--- a/content/download.md
+++ b/content/download.md
@@ -19,7 +19,7 @@ MISP can be easily installed on any standard GNU/Linux distribution. Installatio
 
 ### Recommended distribution
 
-We recommend to use a recent and stable Ubuntu distribution (such as 20.04) for deploying MISP.
+We recommend to use a recent and stable Ubuntu distribution (such as 22.04) for deploying MISP.
 
 ### Virtual images for testing
 


### PR DESCRIPTION
Thank you for maintaining the documentation :)

On the [Download and Install MISP page](https://www.misp-project.org/download/), the recommended Ubuntu version was a bit old(`20.04`), so I changed it to the `22.04` LTS version.(If `20.04` is more recommended, I will close this PR)

I would appreciate it if you could review.
Regards.